### PR TITLE
Add flag to specify role for all org accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ OPTIONAL
 --keep-custom-config=true          Retains any custom profiles or settings. Set to false to remove everything
                                    except the source profile and generated config
 --use-role-name-in-profile=false   Append the role name to the profile name
+--role=STRING                      If set, then a profile with this role will be generated for every account in the organization, in addition to the roles that the user has permissions to assume
 ```
+
+Note: When using the `--role` flag we do not check to see if the user has permission to assume that role. This is useful
+if the user has a policy that allows them e.g. `sts:AssumeRole` on resource `*` and the target accounts
+manage who is allowed to assume various roles.
 
 ### aws-extend-switch-roles
 

--- a/pkg/cmd/cli.go
+++ b/pkg/cmd/cli.go
@@ -17,5 +17,6 @@ package cmd
 type CLI struct {
 	Vault       VaultCmd       `cmd help:"generates a config for aws-vault"`
 	SwitchRoles SwitchRolesCmd `cmd help:"generates a config for aws-extend-switch-roles"`
-	Debug       bool           `help:"set the log level to debug" default:false`
+	Debug       bool           `help:"set the log level to debug" default:"false"`
+	Role        string         `help:"If set, then a profile with this role will be generated for every account in the organization, in addition to the roles that the user has permissions to assume"`
 }

--- a/pkg/cmd/switch_roles.go
+++ b/pkg/cmd/switch_roles.go
@@ -27,7 +27,7 @@ type SwitchRolesCmd struct {
 }
 
 func (swc *SwitchRolesCmd) Run(cli *CLI) error {
-	roleArns, accountMap := util.GetAWSContext().GetRolesAndAccounts()
+	roleArns, accountMap := util.GetAWSContext().GetRolesAndAccounts(cli.Role)
 	generateSwitchRolesProfile(accountMap, roleArns, cli.SwitchRoles)
 
 	return nil

--- a/pkg/cmd/vault.go
+++ b/pkg/cmd/vault.go
@@ -31,7 +31,7 @@ type VaultCmd struct {
 }
 
 func (vc *VaultCmd) Run(cli *CLI) error {
-	roleArns, accountMap := util.GetAWSContext().GetRolesAndAccounts()
+	roleArns, accountMap := util.GetAWSContext().GetRolesAndAccounts(cli.Role)
 	generateVaultProfile(accountMap, roleArns, cli.Vault)
 
 	return nil


### PR DESCRIPTION
When using the `--role` flag, we generate a profile with that role for every account in the organization